### PR TITLE
fix positionToEntityKey types

### DIFF
--- a/packages/contracts/src/positionToEntityKey.sol
+++ b/packages/contracts/src/positionToEntityKey.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
-function positionToEntityKey(uint32 x, uint32 y) pure returns (bytes32) {
+function positionToEntityKey(int32 x, int32 y) pure returns (bytes32) {
   return keccak256(abi.encode(x, y));
 }


### PR DESCRIPTION
Fixes a type issue that was fixed in `step-1` [here](https://github.com/latticexyz/emojimon/commit/b3029c479a702290e2a9f475584ea5fc2534d678#diff-79e62f72564f151cb64543d8cd7ce2c12cb67c5376dc11c8ff1743a5382fa505R4) but there's nothing in the [docs](https://mud.dev/guides/emojimon/3-players-and-movement) saying `positionToEntityKey` should be changed in that step. `positionToEntityKey` should just have the correct types on the `start` branch.